### PR TITLE
Potential fix for code scanning alert no. 1: HTTP Response Splitting

### DIFF
--- a/app/list_server.py
+++ b/app/list_server.py
@@ -106,9 +106,10 @@ class CustomListingAndFileHandler(http.server.BaseHTTPRequestHandler):
             mimetype, _ = mimetypes.guess_type(abs_file_path)
             if mimetype is None:
                 mimetype = 'application/octet-stream' # 如果无法猜测，使用通用二进制流
-
+            # Sanitize mimetype to remove CR, LF, colon to prevent HTTP response splitting
+            safe_mimetype = mimetype.replace('\n', '').replace('\r', '').replace(':', '')
             self.send_response(http.HTTPStatus.OK)
-            self.send_header("Content-type", mimetype)
+            self.send_header("Content-type", safe_mimetype)
             self.send_header("Content-Length", str(os.path.getsize(abs_file_path)))
             # 强烈建议为静态文件添加缓存头，提高客户端加载速度
             self.send_header('Cache-Control', 'public, max-age=31536000') # 缓存一年


### PR DESCRIPTION
Potential fix for [https://github.com/Jackie264/list_server/security/code-scanning/1](https://github.com/Jackie264/list_server/security/code-scanning/1)

To fix this vulnerability, the code should ensure that no value written to the HTTP header contains characters that could break headers (specifically, carriage return `\r`, newline `\n`, or colon `:`), which could allow response splitting. In this case, sanitize the `mimetype` string returned from `mimetypes.guess_type` by removing any suspicious characters before this value is used as a header value. The best way is to replace or remove `\n`, `\r`, and `:` in the MIME type string just before sending the header, ideally using `.replace()` calls. These edits should be applied just before passing `mimetype` to `self.send_header("Content-type", ...)` in line 111. No new imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
