### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/app/list_server.py
+++ b/app/list_server.py
@@ -109,7 +109,12 @@ class CustomListingAndFileHandler(http.server.BaseHTTPRequestHandler):
             if os.path.islink(abs_file_path):
                 self.send_error(http.HTTPStatus.FORBIDDEN, "Symlinks are not allowed for static assets.")
                 return
-
+            # 关键修正：确保文件真实路径仍在 STATIC_ASSETS_DIR 内部，防止 symlink escape
+            abs_static_realroot = os.path.realpath(STATIC_ASSETS_DIR)
+            abs_file_realpath = os.path.realpath(abs_file_path)
+            if not os.path.commonpath([abs_static_realroot, abs_file_realpath]) == abs_static_realroot:
+                self.send_error(http.HTTPStatus.FORBIDDEN, "Resolved file path escapes static assets directory (symlink attack blocked).")
+                return
             # 猜测文件的 MIME 类型
             mimetype, _ = mimetypes.guess_type(abs_file_path)
             if mimetype is None:


### PR DESCRIPTION
Potential fix for [https://github.com/Jackie264/list_server/security/code-scanning/4](https://github.com/Jackie264/list_server/security/code-scanning/4)

To fully fix the issue and harden the code against potential directory traversal using absolute paths or symlink abuse, further constraints should be added:
1. **Reject absolute paths in `sub_path`**: Even though `os.path.normpath` cleans up a path, it may still result in an absolute path if user input starts with `/`. Explicitly reject any request where the decoded or normalized sub-path is absolute.
2. **Optionally, refuse to serve symlinks** (if desired): If static asset directory contents should not include symlinks pointing outside, ensure the file at `abs_file_path` is not a symlink.

_To implement this:_  
- In the `_serve_static_file` method in `app/list_server.py`, after obtaining `normalized_sub_path`, add a check to return HTTP 400 (Bad Request) if it is an absolute path (i.e., `os.path.isabs(normalized_sub_path)`).
- Optionally, before serving the file, reject it if `os.path.islink(abs_file_path)` is `True`.
- These edits should be made in the method `_serve_static_file` within `CustomListingAndFileHandler`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
