### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/app/list_server.py
+++ b/app/list_server.py
@@ -94,22 +94,30 @@ class CustomListingAndFileHandler(http.server.BaseHTTPRequestHandler):
             # 获取请求文件路径的绝对规范化路径
             abs_file_path = os.path.abspath(physical_file_path)
 
-            # 确保请求的文件路径确实位于 STATIC_ASSETS_DIR 之下
+            # Resolve symlinks (real paths) to enforce containment and prevent symlink escapes
+            abs_root_real = os.path.realpath(STATIC_ASSETS_DIR)
+            abs_file_realpath = os.path.realpath(abs_file_path)
+
+            # 确保请求的文件路径确实位于 STATIC_ASSETS_DIR 之下 (防止目录遍历)
             # os.path.commonpath 返回两个或多个路径的最长公共子路径
             if not os.path.commonpath([abs_static_root, abs_file_path]) == abs_static_root:
                 self.send_error(http.HTTPStatus.FORBIDDEN, "Access to requested path outside static assets directory is forbidden.")
                 return
+
+            # 确保解析 symlink 后的路径仍然在 STATIC_ASSETS_DIR 内部，防止 symlink 跳出目录
+            if not os.path.commonpath([abs_root_real, abs_file_realpath]) == abs_root_real:
+                self.send_error(http.HTTPStatus.FORBIDDEN, "Access to requested path outside static assets directory (via symlink) is forbidden.")
+                return
             # --- 结束安全检查 ---
 
             # 检查文件是否存在且是普通文件
-            if not os.path.isfile(abs_file_path):
+            if not os.path.isfile(abs_file_realpath):
                 self.send_error(http.HTTPStatus.NOT_FOUND, "Static file not found.")
                 return
             # 可选加强：禁止提供符号链接（防止 symlink 跳出目录）
-            if os.path.islink(abs_file_path):
+            if os.path.islink(abs_file_realpath):
                 self.send_error(http.HTTPStatus.FORBIDDEN, "Symlinks are not allowed for static assets.")
                 return
-            # 关键修正：确保文件真实路径仍在 STATIC_ASSETS_DIR 内部，防止 symlink escape
             abs_static_realroot = os.path.realpath(STATIC_ASSETS_DIR)
             abs_file_realpath = os.path.realpath(abs_file_path)
             if not os.path.commonpath([abs_static_realroot, abs_file_realpath]) == abs_static_realroot:


### PR DESCRIPTION
Potential fix for [https://github.com/Jackie264/list_server/security/code-scanning/2](https://github.com/Jackie264/list_server/security/code-scanning/2)

To fully address the issue and ensure there is no path traversal or symlink escape vulnerability, you should resolve the physical file path to its real (symlink-resolved) absolute path using `os.path.realpath` and verify that it still lies within the intended static asset root, in addition to the checks already present. Concretely:

- After constructing `abs_file_path`, compute `abs_file_realpath = os.path.realpath(abs_file_path)`.
- Also compute `abs_root_real = os.path.realpath(STATIC_ASSETS_DIR)`.
- Before opening or serving the file, check that `os.path.commonpath([abs_root_real, abs_file_realpath]) == abs_root_real`.
- Use `abs_file_realpath` for checking whether the file exists (`os.path.isfile(abs_file_realpath)`) and when you open-read the file.
- This prevents using symlinks anywhere in the tree to escape the intended static root, even if the symlink is not the final path component.
- You should keep the current checks for absolute path, isfile, and islink for defense-in-depth.

**Required changes:**  
- In `CustomListingAndFileHandler._serve_static_file`:  
  - Define `abs_file_realpath = os.path.realpath(abs_file_path)` and `abs_root_real = os.path.realpath(STATIC_ASSETS_DIR)`
  - Add containment check before file access.
  - Use `abs_file_realpath` in `isfile`, `islink`, and file reading.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
