### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/app/list_server.py
+++ b/app/list_server.py
@@ -131,13 +131,13 @@ class CustomListingAndFileHandler(http.server.BaseHTTPRequestHandler):
             safe_mimetype = mimetype.replace('\n', '').replace('\r', '').replace(':', '')
             self.send_response(http.HTTPStatus.OK)
             self.send_header("Content-type", safe_mimetype)
-            self.send_header("Content-Length", str(os.path.getsize(abs_file_path)))
+            self.send_header("Content-Length", str(os.path.getsize(abs_file_realpath)))
             # 强烈建议为静态文件添加缓存头，提高客户端加载速度
             self.send_header('Cache-Control', 'public, max-age=31536000') # 缓存一年
             self.end_headers()
 
             # 以二进制模式读取文件并写入响应体
-            with open(abs_file_path, 'rb') as f:
+            with open(abs_file_realpath, 'rb') as f:
                 shutil.copyfileobj(f, self.wfile) # 高效地复制文件内容到响应流
             return
 


### PR DESCRIPTION
Potential fix for [https://github.com/Jackie264/list_server/security/code-scanning/3](https://github.com/Jackie264/list_server/security/code-scanning/3)

To fully fix this problem and prevent any potential bypasses:
- Instead of using `abs_file_path` for file operations, use `abs_file_realpath`, which resolves all symlinks and ensures the true file location is contained within the intended static assets directory.
- Ensure all file-system operations (e.g. `open()`, `os.path.getsize()`, etc.) refer only to the fully resolved path (`abs_file_realpath`).
- Double-check that the containment checks are exhaustive and occur before any file operation.
- This change should only occur in the `_serve_static_file` method, specifically replacing uses of `abs_file_path` for file reads/size with `abs_file_realpath`.

No imports or changes to anything else are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
