### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/app/list_server.py
+++ b/app/list_server.py
@@ -104,7 +104,7 @@ class CustomListingAndFileHandler(http.server.BaseHTTPRequestHandler):
             if os.path.islink(abs_file_realpath):
                 self.send_error(http.HTTPStatus.FORBIDDEN, "Symlinks are not allowed for static assets.")
                 return
-            abs_file_realpath = os.path.realpath(abs_file_path)
+            # Re-resolve the path to ensure symlinks have not changed; redundant here as abs_file_realpath is already realpath
             if not os.path.commonpath([abs_static_realroot, abs_file_realpath]) == abs_static_realroot:
                 self.send_error(http.HTTPStatus.FORBIDDEN, "Resolved file path escapes static assets directory (symlink attack blocked).")
                 return


### PR DESCRIPTION
Potential fix for [https://github.com/Jackie264/list_server/security/code-scanning/7](https://github.com/Jackie264/list_server/security/code-scanning/7)

The fix involves correcting the variable misuse in the `_serve_static_file` method. Specifically, change uses of `abs_file_path` (undefined) to `abs_file_realpath` (the properly resolved path). This ensures that security checks are performed on the actual resolved file path and eliminates potential logic errors that could allow bypasses or security holes. The security checks themselves are sound; their effectiveness depends on being performed on the correct path variable. Only edits within the shown code section in `app/list_server.py` are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
