### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/app/list_server.py
+++ b/app/list_server.py
@@ -88,6 +88,8 @@ class CustomListingAndFileHandler(http.server.BaseHTTPRequestHandler):
             candidate_path = os.path.join(STATIC_ASSETS_DIR, normalized_sub_path)
             # 获取 STATIC_ASSETS_DIR 和候选文件的真实路径（解析 symlink）
             abs_static_realroot = os.path.realpath(STATIC_ASSETS_DIR)
+            if not abs_static_realroot.endswith(os.sep):
+                abs_static_realroot = abs_static_realroot + os.sep  # Ensure trailing slash to prevent prefix tricks
             abs_file_realpath = os.path.realpath(candidate_path)
 
             # --- 关键安全检查：只允许真实路径（包含 symlink 解析后）在静态根内部 ---
@@ -109,7 +111,7 @@ class CustomListingAndFileHandler(http.server.BaseHTTPRequestHandler):
                 self.send_error(http.HTTPStatus.FORBIDDEN, "Resolved file path escapes static assets directory (symlink attack blocked).")
                 return
             # 猜测文件的 MIME 类型
-            mimetype, _ = mimetypes.guess_type(abs_file_path)
+            mimetype, _ = mimetypes.guess_type(abs_file_realpath)
             if mimetype is None:
                 mimetype = 'application/octet-stream' # 如果无法猜测，使用通用二进制流
             # Sanitize mimetype to remove CR, LF, colon to prevent HTTP response splitting


### PR DESCRIPTION
Potential fix for [https://github.com/Jackie264/list_server/security/code-scanning/6](https://github.com/Jackie264/list_server/security/code-scanning/6)

To robustly prevent directory traversal and ensure the file access is confined within a known root, we should be sure to:

1. Normalize the requested path (already done).
2. **Resolve* and canonicalize both the static files root and the requested file (`os.path.realpath`), and ensure that *the candidate is strictly inside the root directory*. This is already being done, but we should be explicit: compare `commonpath` but also check that the resolved static root is suffixed with a separator (avoiding prefix attacks: `/feeds_data-not-real`).
3. Disallow any absolute path components, symlinks, or attempts to escape.
4. Always use the checked and sanitized absolute path for filesystem operations.

Specifically, we will:
- Ensure the computed `abs_static_realroot` (the base root directory) is always resolved via `os.path.realpath` and forcibly suffixed with a path separator before the `commonpath` comparison, to guard against prefix attacks.
- Make sure no redundant or inconsistent variables (`abs_file_path` vs `abs_file_realpath`) are used.
- Use consistent naming and ensure the actual path served is the one checked for traversal and symlink attacks.
- Keep all checks in place.
- Fix the variable typo at line 112 (`abs_file_path` should be `abs_file_realpath`).

**Files/edits:**
- Edit only inside `app/list_server.py`, in the `_serve_static_file` method (as per user instruction).
- Add explicit separator to the root path after realpath resolution for guaranteed safety.
- Minor typo fix (`abs_file_path` → `abs_file_realpath`).
- No external dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
