### PR TITLE
Potential fix for code scanning alert no. 9: Uncontrolled data used in path expression

### DIFF
--- a/app/list_server.py
+++ b/app/list_server.py
@@ -87,13 +87,11 @@ class CustomListingAndFileHandler(http.server.BaseHTTPRequestHandler):
             # 构建和规范化目标物理路径
             candidate_path = os.path.join(STATIC_ASSETS_DIR, normalized_sub_path)
             # 获取 STATIC_ASSETS_DIR 和候选文件的真实路径（解析 symlink）
-            abs_static_realroot = os.path.realpath(STATIC_ASSETS_DIR)
-            if not abs_static_realroot.endswith(os.sep):
-                abs_static_realroot = abs_static_realroot + os.sep  # Ensure trailing slash to prevent prefix tricks
-            abs_file_realpath = os.path.realpath(candidate_path)
+            abs_static_realroot = os.path.realpath(os.path.abspath(STATIC_ASSETS_DIR))
+            abs_file_realpath = os.path.realpath(os.path.abspath(candidate_path))
 
             # --- 关键安全检查：只允许真实路径（包含 symlink 解析后）在静态根内部 ---
-            if not os.path.commonpath([abs_static_realroot, abs_file_realpath]) == abs_static_realroot:
+            if os.path.commonpath([abs_static_realroot, abs_file_realpath]) != abs_static_realroot:
                 self.send_error(http.HTTPStatus.FORBIDDEN, "Access to requested path outside static assets directory is forbidden.")
                 return
             # --- 结束安全检查 ---


### PR DESCRIPTION
Potential fix for [https://github.com/Jackie264/list_server/security/code-scanning/9](https://github.com/Jackie264/list_server/security/code-scanning/9)

The best way to eliminate any residual directory traversal or symlink attack risk is:

- Ensure `STATIC_ASSETS_DIR` is always an absolute, normalized path (using `os.path.abspath`, `os.path.normpath`).
- When checking if the requested file is contained in this directory, use `os.path.commonpath([abs_static_realroot, abs_file_realpath]) == abs_static_realroot` where both are normalized absolute real paths, and **do not** rely on trailing slashes or string checks.
- Optionally, call `os.path.abspath()` after joining and normalizing the candidate path to further eliminate weird edge cases.
- Remove the unnecessary trailing slash manipulation with `endswith(os.sep)`, as `os.path.commonpath()` does not require it if paths are constructed via `os.path.realpath()`.
- Provide an additional check for absolute/relative path manipulation (e.g., paths containing `..` after normalization).
- Consider limiting input filenames to a safe format (letters/numbers, dashes, etc.) via a regex if possible.

Specifically, in `app/list_server.py`, lines 91–92 can be improved to eliminate reliance on a trailing separator; use only canonicalized, real paths and verify with `os.path.commonpath`. Remove the trailing separator hack altogether.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
