### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/app/list_server.py
+++ b/app/list_server.py
@@ -91,6 +91,7 @@ class CustomListingAndFileHandler(http.server.BaseHTTPRequestHandler):
             abs_file_realpath = os.path.realpath(os.path.abspath(candidate_path))
 
             # --- 关键安全检查：只允许真实路径（包含 symlink 解析后）在静态根内部 ---
+            # Only allow access if the resolved file path is strictly under the static assets root.
             if os.path.commonpath([abs_static_realroot, abs_file_realpath]) != abs_static_realroot:
                 self.send_error(http.HTTPStatus.FORBIDDEN, "Access to requested path outside static assets directory is forbidden.")
                 return
@@ -104,10 +105,8 @@ class CustomListingAndFileHandler(http.server.BaseHTTPRequestHandler):
             if os.path.islink(abs_file_realpath):
                 self.send_error(http.HTTPStatus.FORBIDDEN, "Symlinks are not allowed for static assets.")
                 return
-            # Re-resolve the path to ensure symlinks have not changed; redundant here as abs_file_realpath is already realpath
-            if not os.path.commonpath([abs_static_realroot, abs_file_realpath]) == abs_static_realroot:
-                self.send_error(http.HTTPStatus.FORBIDDEN, "Resolved file path escapes static assets directory (symlink attack blocked).")
-                return
+            # 安全检查已于上方完成，无需重复 commonpath 校验
+
             # 猜测文件的 MIME 类型
             mimetype, _ = mimetypes.guess_type(abs_file_realpath)
             if mimetype is None:


### PR DESCRIPTION
Potential fix for [https://github.com/Jackie264/list_server/security/code-scanning/6](https://github.com/Jackie264/list_server/security/code-scanning/6)

To completely fix this, ensure the comparison for subdirectory containment cannot be bypassed if, for example, the static assets root is `/feeds_data`, and the file path resolved is `/feeds_data_malicious/foo`. This can happen if, after normalization, the attacker manages a subpath with a partial prefix match. The safest fix is to ensure that `abs_file_realpath` is inside the static root by requiring that its *path components* begin with those of the root. The most robust check is to append a separator (os.sep) to `abs_static_realroot` in the prefix check, or, better yet, use `os.path.commonpath`:  
```py
if os.path.commonpath([abs_static_realroot, abs_file_realpath]) != abs_static_realroot:
```
which is already being done.

To absolutely harden this and silence even theoretical static analysis warnings, you can:
- Normalize both paths so they are both real, absolute, without redundant separators;
- Ensure the `commonpath` check is made *once* and only continue if the candidate file is guaranteed under the intended root.

Also, *reduce redundant security checks* (notice that the code has the commonpath check twice, on lines 94 and 108).
Thus:
- **Replace the current check with a single, very clear safety check before any filesystem access.**
- **Add an explicit trailing separator where necessary to prevent partial prefix matches (though with `commonpath` this is not strictly necessary).**
- *Optionally:* After all checks, use `abs_file_realpath` for file access as currently done.

No new imports are needed, but you can clarify comments.
All changes are in the `_serve_static_file` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
